### PR TITLE
refactor: Move from only one region to place (text) and EventRegion

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -27,9 +27,14 @@ class Event
     protected $text;
 
     /**
-     * @var EventPlace $place Place this event happens at
+     * @var string $place Place this event happens at
      */
     protected $place;
+
+    /**
+     * @var EventRegion $region Region this event happens at
+     */
+    protected $region;
 
     /**
      * @var Carbon $start Moment of start
@@ -90,19 +95,35 @@ class Event
     }
 
     /**
-     * @return EventPlace
+     * @return string
      */
-    public function getPlace(): EventPlace
+    public function getPlace(): string
     {
         return $this->place;
     }
 
     /**
-     * @param EventPlace $place
+     * @param string $place
      */
-    public function setPlace(EventPlace $place): void
+    public function setPlace(string $place): void
     {
         $this->place = $place;
+    }
+
+    /**
+     * @return EventRegion
+     */
+    public function getRegion(): EventRegion
+    {
+        return $this->region;
+    }
+
+    /**
+     * @param EventRegion $region
+     */
+    public function setRegion(EventRegion $region): void
+    {
+        $this->region = $region;
     }
 
     /**

--- a/src/Model/EventRegion.php
+++ b/src/Model/EventRegion.php
@@ -7,7 +7,7 @@ namespace Kiefernwald\Affair\Model;
  *
  * @package Kiefernwald\Affair\Model
  */
-class EventPlace
+class EventRegion
 {
     /**
      * @var string $title Title of place.

--- a/src/Services/Affair.php
+++ b/src/Services/Affair.php
@@ -4,7 +4,7 @@ namespace Kiefernwald\Affair\Services;
 
 use Carbon\Carbon;
 use Kiefernwald\Affair\Model\Event;
-use Kiefernwald\Affair\Model\EventPlace;
+use Kiefernwald\Affair\Model\EventRegion;
 
 /**
  * Affair main service implementation
@@ -34,12 +34,12 @@ class Affair implements AffairInterface
      *
      * @param Carbon|null $start Moment of start (defaults to now if not given)
      * @param Carbon|null $end Moment of end (defaults to +3 months if not given)
-     * @param EventPlace|null $place Place to filter by
+     * @param EventRegion|null $region Region to filter by
      * @param int|null $maxResults Max number of results to be returned
      *
      * @return array<Event> List of events (empty if none was found)
      */
-    public function getEvents(?Carbon $start = null, ?Carbon $end = null, ?EventPlace $place = null, ?int $maxResults = self::MAX_EVENTS): array
+    public function getEvents(?Carbon $start = null, ?Carbon $end = null, ?EventRegion $region = null, ?int $maxResults = self::MAX_EVENTS): array
     {
         if (empty($start)) {
             $start = Carbon::now();
@@ -48,7 +48,7 @@ class Affair implements AffairInterface
             $end = Carbon::now()->addMonths(3);
         }
 
-        return $this->eventProvider->provideMany($start, $end, $place, $maxResults);
+        return $this->eventProvider->provideMany($start, $end, $region, $maxResults);
     }
 
     /**
@@ -67,7 +67,8 @@ class Affair implements AffairInterface
      *
      * @param string $title Event title
      * @param string $text Event description
-     * @param EventPlace $place Place of event
+     * @param string $place Place of event
+     * @param EventRegion $region Region of event
      * @param Carbon $start Start date (time is optional)
      * @param Carbon|null $end End date (time is optional)
      * @return Event Created event
@@ -75,7 +76,8 @@ class Affair implements AffairInterface
     public function createEvent(
         string $title,
         string $text,
-        EventPlace $place,
+        string $place,
+        EventRegion $region,
         Carbon $start,
         ?Carbon $end = null
     ): Event
@@ -86,6 +88,7 @@ class Affair implements AffairInterface
         $event->setStart($start);
         $event->setEnd($end);
         $event->setPlace($place);
+        $event->setRegion($region);
 
         $this->eventProvider->storeEvent($event);
 

--- a/src/Services/AffairInterface.php
+++ b/src/Services/AffairInterface.php
@@ -4,7 +4,7 @@ namespace Kiefernwald\Affair\Services;
 
 use Carbon\Carbon;
 use Kiefernwald\Affair\Model\Event;
-use Kiefernwald\Affair\Model\EventPlace;
+use Kiefernwald\Affair\Model\EventRegion;
 
 /**
  * Main service interface
@@ -20,12 +20,12 @@ interface AffairInterface
      *
      * @param Carbon|null $start Moment of start (defaults to now if not given)
      * @param Carbon|null $end Moment of end (defaults to +3 months if not given)
-     * @param EventPlace|null $place Place to filter by
+     * @param EventRegion|null $region Place to filter by
      * @param int|null $maxResults Max number of results to be returned
      *
      * @return array<Event> List of events (empty if none was found)
      */
-    public function getEvents(?Carbon $start = null, ?Carbon $end = null, ?EventPlace $place = null, ?int $maxResults = self::MAX_EVENTS): array;
+    public function getEvents(?Carbon $start = null, ?Carbon $end = null, ?EventRegion $region = null, ?int $maxResults = self::MAX_EVENTS): array;
 
     /**
      * Returns a single event by given ID.
@@ -40,7 +40,8 @@ interface AffairInterface
      *
      * @param string $title Event title
      * @param string $text Event description
-     * @param EventPlace $place Place of event
+     * @param string $place Place of event
+     * @param EventRegion $region Region of event
      * @param Carbon $start Start date (time is optional)
      * @param Carbon|null $end End date (time is optional)
      * @return Event Created event
@@ -48,7 +49,8 @@ interface AffairInterface
     public function createEvent(
         string $title,
         string $text,
-        EventPlace $place,
+        string $place,
+        EventRegion $region,
         Carbon $start,
         ?Carbon $end = null
     ): Event;

--- a/src/Services/EventProviderInterface.php
+++ b/src/Services/EventProviderInterface.php
@@ -4,7 +4,7 @@ namespace Kiefernwald\Affair\Services;
 
 use Carbon\Carbon;
 use Kiefernwald\Affair\Model\Event;
-use Kiefernwald\Affair\Model\EventPlace;
+use Kiefernwald\Affair\Model\EventRegion;
 
 /**
  * Interface describing a data provider
@@ -26,14 +26,14 @@ interface EventProviderInterface
      *
      * @param Carbon $start Start date
      * @param Carbon $end End date
-     * @param EventPlace|null $place Place to filter by
+     * @param EventRegion|null $place Place to filter by
      * @param int $maxResults Max number of results
      * @return array
      */
     public function provideMany(
         Carbon $start,
         Carbon $end,
-        ?EventPlace $place = null,
+        ?EventRegion $place = null,
         int $maxResults = AffairInterface::MAX_EVENTS
     ): array;
 

--- a/src/Services/EventProviderInterface.php
+++ b/src/Services/EventProviderInterface.php
@@ -26,14 +26,14 @@ interface EventProviderInterface
      *
      * @param Carbon $start Start date
      * @param Carbon $end End date
-     * @param EventRegion|null $place Place to filter by
+     * @param EventRegion|null $region Region to filter by
      * @param int $maxResults Max number of results
      * @return array
      */
     public function provideMany(
         Carbon $start,
         Carbon $end,
-        ?EventRegion $place = null,
+        ?EventRegion $region = null,
         int $maxResults = AffairInterface::MAX_EVENTS
     ): array;
 

--- a/tests/Services/AffairTest.php
+++ b/tests/Services/AffairTest.php
@@ -4,7 +4,7 @@ namespace Kiefernwald\Affair\Tests\Services;
 
 use Carbon\Carbon;
 use Kiefernwald\Affair\Model\Event;
-use Kiefernwald\Affair\Model\EventPlace;
+use Kiefernwald\Affair\Model\EventRegion;
 use Kiefernwald\Affair\Services\Affair;
 use Kiefernwald\Affair\Services\AffairInterface;
 use Kiefernwald\Affair\Services\EventProviderInterface;
@@ -76,7 +76,8 @@ class AffairTest extends TestCase
         $testEvent = new Event();
         $testEvent->setTitle('Test title');
         $testEvent->setText('Test text');
-        $testEvent->setPlace(new EventPlace());
+        $testEvent->setPlace('Test place');
+        $testEvent->setRegion(new EventRegion());
         $testEvent->setStart(Carbon::now());
         $testEvent->setEnd(Carbon::now()->addDay());
 
@@ -92,6 +93,7 @@ class AffairTest extends TestCase
                 $testEvent->getTitle(),
                 $testEvent->getText(),
                 $testEvent->getPlace(),
+                $testEvent->getRegion(),
                 $testEvent->getStart(),
                 $testEvent->getEnd()
             )
@@ -111,7 +113,8 @@ class AffairTest extends TestCase
         $testEvent = new Event();
         $testEvent->setTitle('Test title');
         $testEvent->setText('Test text');
-        $testEvent->setPlace(new EventPlace());
+        $testEvent->setPlace('Test place');
+        $testEvent->setRegion(new EventRegion());
         $testEvent->setStart($startTime);
         $testEvent->setEnd($endTime);
 


### PR DESCRIPTION
* `EventPlace` class is now called `EventRegion`
* `place` property of `Event` class is now a string
* introduced new `region` property of `Event` class to hold `EventRegion`